### PR TITLE
support multi install targets

### DIFF
--- a/src/main/java/com/loopperfect/buckaroo/DependencyGroup.java
+++ b/src/main/java/com/loopperfect/buckaroo/DependencyGroup.java
@@ -50,6 +50,26 @@ public final class DependencyGroup {
                 .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
+    public DependencyGroup addDependencyGroup(final DependencyGroup dependencyGroup) {
+        Preconditions.checkNotNull(dependencyGroup);
+        if(dependencyGroup.dependencies.entrySet()
+            .stream()
+            .allMatch((entry) -> dependencies.containsKey(entry.getKey()) &&
+                                 dependencies.get(entry.getKey()).equals(entry.getValue())))
+        {
+            return this;
+        }
+
+        return new DependencyGroup(
+            Stream.concat(
+                dependencies.entrySet()
+                    .stream()
+                    .filter(x -> !dependencyGroup.dependencies.containsKey(x.getKey())),
+                dependencyGroup.dependencies.entrySet()
+                    .stream())
+                .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
     public DependencyGroup removeDependency(final RecipeIdentifier identifier) {
         Preconditions.checkNotNull(identifier);
         if (!dependencies.containsKey(identifier)) {

--- a/src/main/java/com/loopperfect/buckaroo/Project.java
+++ b/src/main/java/com/loopperfect/buckaroo/Project.java
@@ -24,6 +24,11 @@ public final class Project {
         return new Project(name, license, dependencies.addDependency(dependency));
     }
 
+    public Project addDependencyGroup(final DependencyGroup dependencyGroup) {
+        Preconditions.checkNotNull(dependencyGroup);
+        return new Project(name, license, dependencies.addDependencyGroup(dependencyGroup));
+    }
+
     public Project removeDependency(final RecipeIdentifier identifier) {
         Preconditions.checkNotNull(identifier);
         return new Project(name, license, dependencies.removeDependency(identifier));

--- a/src/main/java/com/loopperfect/buckaroo/cli/CLIParsers.java
+++ b/src/main/java/com/loopperfect/buckaroo/cli/CLIParsers.java
@@ -1,5 +1,6 @@
 package com.loopperfect.buckaroo.cli;
 
+import com.google.common.collect.Maps;
 import com.loopperfect.buckaroo.Identifier;
 import com.loopperfect.buckaroo.RecipeIdentifier;
 import com.loopperfect.buckaroo.versioning.VersioningParsers;
@@ -7,6 +8,8 @@ import org.jparsec.Parser;
 import org.jparsec.Parsers;
 import org.jparsec.Scanners;
 import org.jparsec.pattern.CharPredicates;
+
+import java.util.Optional;
 
 public final class CLIParsers {
 
@@ -84,15 +87,14 @@ public final class CLIParsers {
                 Parsers.sequence(
                         installTokenParser
                                 .followedBy(Scanners.WHITESPACES.atLeast(1)),
-                    recipeIdentifierParser,
+                    Parsers.sequence(
+                        recipeIdentifierParser,
+                        VersioningParsers.semanticVersionRequirementParser
+                            .map(v -> Optional.of(v))
+                            .optional(Optional.empty()),
+                        (x,y) -> Maps.immutableEntry(x,y)
+                    ).followedBy(Scanners.WHITESPACES.atLeast(0)).many1(),
                         (x, y) -> InstallCommand.of(y))
-                        .between(ignoreParser, ignoreParser),
-                Parsers.sequence(
-                        installTokenParser
-                                .followedBy(Scanners.WHITESPACES.atLeast(1)),
-                    recipeIdentifierParser,
-                        VersioningParsers.semanticVersionRequirementParser,
-                        (x, y, z) -> InstallCommand.of(y, z))
                         .between(ignoreParser, ignoreParser));
 
     static final Parser<UninstallCommand> uninstallCommandParser =

--- a/src/main/java/com/loopperfect/buckaroo/cli/CLIParsers.java
+++ b/src/main/java/com/loopperfect/buckaroo/cli/CLIParsers.java
@@ -93,7 +93,7 @@ public final class CLIParsers {
                             .map(v -> Optional.of(v))
                             .optional(Optional.empty()),
                         (x,y) -> Maps.immutableEntry(x,y)
-                    ).followedBy(Scanners.WHITESPACES.atLeast(0)).many1(),
+                    ).between(ignoreParser,ignoreParser).many1(),
                         (x, y) -> InstallCommand.of(y))
                         .between(ignoreParser, ignoreParser));
 

--- a/src/main/java/com/loopperfect/buckaroo/cli/InstallCommand.java
+++ b/src/main/java/com/loopperfect/buckaroo/cli/InstallCommand.java
@@ -61,6 +61,7 @@ public final class InstallCommand implements CLICommand {
     public static InstallCommand of(final List<Map.Entry<RecipeIdentifier,Optional<SemanticVersionRequirement>>> projects) {
         return new InstallCommand(
                 projects.stream()
+                        .distinct()
                         .collect(ImmutableMap.toImmutableMap( Map.Entry::getKey, Map.Entry::getValue )));
     }
 }

--- a/src/main/java/com/loopperfect/buckaroo/cli/InstallCommand.java
+++ b/src/main/java/com/loopperfect/buckaroo/cli/InstallCommand.java
@@ -1,35 +1,34 @@
 package com.loopperfect.buckaroo.cli;
 
 import com.google.common.base.Preconditions;
-import com.loopperfect.buckaroo.Identifier;
+import com.google.common.collect.ImmutableMap;
 import com.loopperfect.buckaroo.RecipeIdentifier;
 import com.loopperfect.buckaroo.SemanticVersionRequirement;
 import com.loopperfect.buckaroo.Unit;
 import com.loopperfect.buckaroo.io.IO;
 import com.loopperfect.buckaroo.routines.Install;
-import com.loopperfect.buckaroo.routines.Routines;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 public final class InstallCommand implements CLICommand {
 
-    public final RecipeIdentifier project;
-    public final Optional<SemanticVersionRequirement> versionRequirement;
+    public final ImmutableMap<RecipeIdentifier, Optional<SemanticVersionRequirement>> targets;
 
-    private InstallCommand(final RecipeIdentifier project, final Optional<SemanticVersionRequirement> versionRequirement) {
-        this.project = Preconditions.checkNotNull(project);
-        this.versionRequirement = Preconditions.checkNotNull(versionRequirement);
+    private InstallCommand(final ImmutableMap<RecipeIdentifier, Optional<SemanticVersionRequirement>> targets) {
+        this.targets = Preconditions.checkNotNull(targets);
     }
 
     @Override
     public IO<Unit> routine() {
-        return Install.routine(project, versionRequirement);
+        return Install.routine(targets);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(project, versionRequirement);
+        return Objects.hash(targets);
     }
 
     @Override
@@ -44,19 +43,24 @@ public final class InstallCommand implements CLICommand {
 
         final InstallCommand other = (InstallCommand) obj;
 
-        return Objects.equals(project, other.project) &&
-            Objects.equals(versionRequirement, other.versionRequirement);
+        return Objects.equals(targets, other.targets);
     }
 
     public static InstallCommand of(final RecipeIdentifier project, final Optional<SemanticVersionRequirement> versionRequirement) {
-        return new InstallCommand(project, versionRequirement);
+        return new InstallCommand(ImmutableMap.of(project, versionRequirement));
     }
 
     public static InstallCommand of(final RecipeIdentifier project, final SemanticVersionRequirement versionRequirement) {
-        return new InstallCommand(project, Optional.of(versionRequirement));
+        return new InstallCommand(ImmutableMap.of(project, Optional.of(versionRequirement)));
     }
 
     public static InstallCommand of(final RecipeIdentifier project) {
-        return new InstallCommand(project, Optional.empty());
+        return new InstallCommand(ImmutableMap.of(project, Optional.empty()));
+    }
+
+    public static InstallCommand of(final List<Map.Entry<RecipeIdentifier,Optional<SemanticVersionRequirement>>> projects) {
+        return new InstallCommand(
+                projects.stream()
+                        .collect(ImmutableMap.toImmutableMap( Map.Entry::getKey, Map.Entry::getValue )));
     }
 }

--- a/src/test/java/com/loopperfect/buckaroo/cli/CLIParsersTest.java
+++ b/src/test/java/com/loopperfect/buckaroo/cli/CLIParsersTest.java
@@ -1,12 +1,15 @@
 package com.loopperfect.buckaroo.cli;
 
+import com.google.common.collect.Maps;
 import com.google.gson.JsonParseException;
 import com.loopperfect.buckaroo.*;
 import org.jparsec.Parser;
 import org.jparsec.error.ParserException;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -100,6 +103,12 @@ public final class CLIParsersTest {
         assertEquals(
             InstallCommand.of(RecipeIdentifier.of("org", "another-lib2"), ExactSemanticVersion.of(SemanticVersion.of(2))),
             CLIParsers.commandParser.parse("install org/another-lib2 [ 2 ]  "));
+
+        assertEquals(
+            InstallCommand.of(Arrays.asList(Maps.immutableEntry(RecipeIdentifier.of("org", "some_lib"), Optional.empty()),
+                                            Maps.immutableEntry(RecipeIdentifier.of("org", "another-lib2"),
+                                                                Optional.of(ExactSemanticVersion.of(SemanticVersion.of(2)))))),
+            CLIParsers.commandParser.parse("install org/some_lib org/another-lib2 [ 2 ]  "));
 
         assertEquals(
             UpdateCommand.of(Identifier.of("boost-config")),

--- a/src/test/java/com/loopperfect/buckaroo/cli/CLIParsersTest.java
+++ b/src/test/java/com/loopperfect/buckaroo/cli/CLIParsersTest.java
@@ -111,6 +111,10 @@ public final class CLIParsersTest {
             CLIParsers.commandParser.parse("install org/some_lib org/another-lib2 [ 2 ]  "));
 
         assertEquals(
+            InstallCommand.of(Arrays.asList(Maps.immutableEntry(RecipeIdentifier.of("org", "some_lib"), Optional.empty()))),
+            CLIParsers.commandParser.parse("install org/some_lib org/some_lib "));
+
+        assertEquals(
             UpdateCommand.of(Identifier.of("boost-config")),
             CLIParsers.commandParser.parse(" uPdAte  boost-config "));
 


### PR DESCRIPTION
This PR is aimed to support that install command accepts a list.(https://github.com/LoopPerfect/buckaroo/issues/51)

The output of running this pull request is the following.
It accepts multi install targets as list.

    $buckaroo install eigen/eigen ar90n/msgpack11  0.0.7
    Adding dependency on eigen/eigen,ar90n/msgpack11@0.0.7...
    Done.
    Installing dependencies...
    Installing eigen/eigen@3.2.9...
    Installing ar90n/msgpack11@0.0.7...
    Success!

Unfortunately, I am not familiar with Java.
So it may have a lot of undesirable codes.
If so, please tell me them.
I'll fix it promptly.
