### PR TITLE
Support close target suggestion

### DIFF
--- a/src/main/java/com/loopperfect/buckaroo/CookbookDependencyFetcher.java
+++ b/src/main/java/com/loopperfect/buckaroo/CookbookDependencyFetcher.java
@@ -3,15 +3,44 @@ package com.loopperfect.buckaroo;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 import java.util.Map;
+import java.util.stream.IntStream;
 
 public final class CookbookDependencyFetcher implements DependencyFetcher {
 
+    static final int CandidateThreshold = 3;
     final ImmutableList<CookBook> cookBooks;
 
     private CookbookDependencyFetcher(final ImmutableList<CookBook> cookBooks) {
         this.cookBooks = Preconditions.checkNotNull(cookBooks);
+    }
+
+    private static int calcRecipeDistance(final RecipeIdentifier cookbookEntry, final RecipeIdentifier project)
+    {
+        Preconditions.checkNotNull(cookbookEntry);
+        Preconditions.checkNotNull(project);
+
+        final String encodedCookbookEntry = cookbookEntry.encode();
+        final String encodedProject = project.encode();
+        final String minor = (encodedCookbookEntry.length() < encodedProject.length()) ? encodedCookbookEntry : encodedProject;
+        final String major = (encodedCookbookEntry.length() < encodedProject.length()) ? encodedProject : encodedCookbookEntry;
+
+        final int[] memo = IntStream.rangeClosed(0, minor.length()).toArray();
+        for(char x : major.toCharArray())
+        {
+            int prev = memo[0];
+            memo[0]++;
+            for( int j = 1; j <= minor.length(); ++j)
+            {
+                final int substitution = prev + (x == minor.charAt(j-1) ? 0 : 1);
+                prev = memo[j];
+                memo[j] = Math.min(substitution, Math.min(memo[j-1], memo[j]) + 1);
+            }
+        }
+
+        return memo[minor.length()];
     }
 
     @Override
@@ -21,18 +50,26 @@ public final class CookbookDependencyFetcher implements DependencyFetcher {
         Preconditions.checkNotNull(project);
         Preconditions.checkNotNull(versionRequirement);
 
-        final ImmutableList<Recipe> recipes = cookBooks.stream()
+        final ImmutableList<Map.Entry<RecipeIdentifier,Recipe>> candidateRecipes = cookBooks.stream()
                 .flatMap(x -> x.organizations
                         .entrySet()
                         .stream()
                         .flatMap(y -> y.getValue().recipes.entrySet()
                                 .stream()
-                                .filter(z -> RecipeIdentifier.of(y.getKey(), z.getKey()).equals(project))
-                                .map(Map.Entry::getValue)))
+                                .map(z -> Maps.immutableEntry(RecipeIdentifier.of(y.getKey(), z.getKey()), z.getValue()))
+                                .filter(z -> calcRecipeDistance(z.getKey(), project) < CandidateThreshold)))
+                .collect(ImmutableList.toImmutableList());
+
+        final ImmutableList<Recipe> recipes = candidateRecipes.stream()
+                .filter(x -> x.getKey().equals(project))
+                .map(x -> x.getValue())
                 .collect(ImmutableList.toImmutableList());
 
         if (recipes.isEmpty()) {
-            return Either.left(new ProjectNotFoundException(project));
+            final ImmutableList<RecipeIdentifier> closeIds = candidateRecipes.stream()
+                    .map(x -> x.getKey())
+                    .collect(ImmutableList.toImmutableList());
+            return Either.left(new ProjectNotFoundException(project, closeIds));
         }
 
         return Either.right(recipes.stream()

--- a/src/main/java/com/loopperfect/buckaroo/ProjectNotFoundException.java
+++ b/src/main/java/com/loopperfect/buckaroo/ProjectNotFoundException.java
@@ -1,11 +1,42 @@
 package com.loopperfect.buckaroo;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class ProjectNotFoundException extends DependencyResolverException {
 
+    public final ImmutableList<RecipeIdentifier> closeIds;
+
+    private static String createMessage(final RecipeIdentifier id, final ImmutableList<RecipeIdentifier> closeIds){
+        StringBuilder builder = new StringBuilder("There is no package called")
+            .append(" \"")
+            .append(id.encode())
+            .append("\".");
+
+        if( closeIds != null && !closeIds.isEmpty())
+        {
+            builder.append("\n")
+                .append("Do you mean ")
+                .append(closeIds.stream()
+                        .flatMap( x -> Stream.of(",", x.toString()))
+                        .skip(1)
+                        .collect(Collectors.joining()))
+                .append(" ?");
+        }
+
+        return builder.toString();
+    }
+
     public ProjectNotFoundException(final RecipeIdentifier id){
-        super(id, "Project not found " + id.encode());
+        this(id, ImmutableList.of());
+    }
+
+    public ProjectNotFoundException(final RecipeIdentifier id, final ImmutableList<RecipeIdentifier> closeIds){
+        super(id, createMessage(id, closeIds));
+        this.closeIds = closeIds;
     }
 
     @Override
@@ -21,6 +52,6 @@ public final class ProjectNotFoundException extends DependencyResolverException 
 
         final ProjectNotFoundException other = (ProjectNotFoundException) obj;
 
-        return Objects.equals(id, other.id);
+        return Objects.equals(id, other.id) && Objects.equals(closeIds, other.closeIds);
     }
 }

--- a/src/test/java/com/loopperfect/buckaroo/DependencyResolverTest.java
+++ b/src/test/java/com/loopperfect/buckaroo/DependencyResolverTest.java
@@ -163,6 +163,20 @@ public final class DependencyResolverTest {
             DependencyResolver.resolve(project.dependencies, fetcher);
 
         assertEquals(expected, actual);
+
+        final Project project2 = Project.of("project", DependencyGroup.of(ImmutableMap.of(
+                RecipeIdentifier.of("org", "fo"), AnySemanticVersion.of())));
+
+        final Either<ImmutableList<DependencyResolverException>, ImmutableMap<RecipeIdentifier, SemanticVersion>> expected2 =
+                Either.left(ImmutableList.of(
+                        new ProjectNotFoundException(
+                                RecipeIdentifier.of("org", "fo"),
+                                ImmutableList.of(RecipeIdentifier.of("org", "foo")))));
+
+        final Either<ImmutableList<DependencyResolverException>, ImmutableMap<RecipeIdentifier, SemanticVersion>> actual2 =
+                DependencyResolver.resolve(project2.dependencies, fetcher);
+
+        assertEquals(expected2, actual2);
     }
 
     @Test


### PR DESCRIPTION
This PR is aimed to solve the https://github.com/LoopPerfect/buckaroo/issues/13 .
It tries to achieve by the following steps.

1.  Calculate Levenshtein distance between input recipe identification and all recipe identifications in cookbook.
2.  Drop recipes identifications which have distance more than specified threshold.
3.  if there is not a recipe identification which equals to the input recipe identification in cookbook, throw an exeption which contains close recipe identifications.

The output of this PR is following.

    buckaroo install bot/any
    Adding dependency on bot/any...
    Could not resolve a dependency.
    [com.loopperfect.buckaroo.ProjectNotFoundException: There is no package called "bot/any".
    Do you mean boost/any ?]

I think there is still a problem about display style.
But it should be solved in the https://github.com/LoopPerfect/buckaroo/issues/11 .

