### PR TITLE
adding help options

### DIFF
--- a/src/main/java/com/loopperfect/buckaroo/cli/HelpCommand.java
+++ b/src/main/java/com/loopperfect/buckaroo/cli/HelpCommand.java
@@ -25,8 +25,33 @@ public final class HelpCommand implements CLICommand {
 
     @Override
     public Function<FileSystem, Observable<Event>> routine() {
-        return fs -> Observable.just(Notification.of("Read the docs at: \n" +
-            "https://buckaroo.readthedocs.io/en/latest/cli.html"));
+        return fs -> Observable.just(Notification.of("\n"
+                        + "    The C++ package manager that will take you to your happy place\n\n"
+                        + "    Usage\n\n"
+                        + "      $ buckaroo <options...>\n\n"
+                        + "    Options\n\n"
+                        + "      init         Init is used to generate a project file in the current\n"
+                        + "                   directory\n"
+                        + "      quckstart    Similar to init but also generates the necessary\n"
+                        + "                   boiler-plate for a new C++ project\n"
+                        + "      resolve      Reads the project file in the working directory and runs\n"
+                        + "                   the dependency resolution algorithm, storing the results\n"
+                        + "                   in the lock file\n"
+                        + "      install      Adds and installs dependencies to your project\n"
+                        + "      uninstall    Remove a dependency from your project\n"
+                        + "      upgrade      Upgrades the installed dependencies to the latest compatible\n"
+                        + "                   version\n"
+                        + "      update       Updates the cook-books installed on your system\n"
+                        + "      version      Outputs the version of Buckaroo that is installed\n"
+                        + "      help         Outputs this help message\n\n"
+                        + "    Examples\n\n"
+                        + "      $ buckaroo install google/gtest\n      ...\n"
+                        + "      $ buckaroo install github+loopperfect/neither\n      ...\n\n"
+                        + "    For more information read the docs at:\n"
+                        + "    https://buckaroo.readthedocs.io/en/latest/cli.html\n"
+
+                )
+        );
     }
 
     public static HelpCommand of() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On this pull request I am just adding help options while `$ buckaroo help`.

## Related Issue

This partially fix #133 but I still think we need to provide/create a parser for getting flags from the user (`--flag`, `-f`) and as #65 

## Motivation and Context

This will save time for devs to learn to use **buckaroo**.

## Screenshots (if appropriate):

###### Before

<img width="743" alt="before" src="https://user-images.githubusercontent.com/21347264/48040508-3866f800-e147-11e8-8dd2-fc8b5b7d5825.png">

###### After 

![after](https://user-images.githubusercontent.com/21347264/48040518-461c7d80-e147-11e8-8f1c-bcc1e943f899.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] ~~Bug fix~~ (non-breaking change which fixes an issue) *not a bug but it should close #133* 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
