### PR TITLE
 * Makes sem-ver parser more lenient

### DIFF
--- a/buckaroo-tests/SemVer.fs
+++ b/buckaroo-tests/SemVer.fs
@@ -6,7 +6,7 @@ open Xunit
 open Buckaroo
 
 let dropError<'T, 'E> (x : Result<'T, 'E>) =
-  match x with 
+  match x with
   | Result.Ok o -> Some o
   | Result.Error _ -> None
 
@@ -29,6 +29,8 @@ let ``SemVer.parse works correctly`` () =
     ("", None);
     ("abc", None);
     ("v0.9.0-g++-4.9", None);
+    ("boost-1.66.0", Some { SemVer.zero with Major = 1; Minor = 66 });
+    ("boost-1.64.0-beta2", None);
   ]
   for (input, expected) in cases do
     Assert.Equal(expected, SemVer.parse input |> dropError)

--- a/buckaroo/SemVer.fs
+++ b/buckaroo/SemVer.fs
@@ -49,14 +49,28 @@ module SemVer =
       |> Seq.fold (fun acc elem -> acc * 10 + elem) 0
   }
 
+  let prefixParser = parse {
+    do!
+      CharParsers.asciiLetter
+      |> Primitives.many1
+      |>> ignore
+    do! CharParsers.skipString "-"
+  }
+
   let parser : Parser<SemVer, unit> = parse {
     do! CharParsers.spaces
-    do! CharParsers.skipString "v" <|> CharParsers.skipString "V" |> Primitives.optional
+    do!
+      (attempt prefixParser)
+      <|> CharParsers.skipString "v"
+      <|> CharParsers.skipString "V"
+      |> Primitives.optional
+
     let! major = integerParser
     let segment = parse {
       do! CharParsers.skipString "."
       return! integerParser
     }
+
     let! minor = segment |> Primitives.opt
     let! patch = segment |> Primitives.opt
     let! increment = segment |> Primitives.opt


### PR DESCRIPTION
For Patch Bot :robot: we need `boost-1.64.0` etc. to parse as sem-vers. 