### PR TITLE
fixes fetch commits and terminates exponential deepening if all commits fetched

### DIFF
--- a/buckaroo/DefaultSourceExplorer.fs
+++ b/buckaroo/DefaultSourceExplorer.fs
@@ -101,7 +101,7 @@ type DefaultSourceExplorer (console : ConsoleManager, downloadManager : Download
     match maybeBranchRef with
     | Some branchRef ->
       yield branchRef.Revision
-      yield! gitManager.FetchCommits url branchRef.Revision
+      yield! gitManager.FetchCommits url branchRef.Name
       ()
     | None -> ()
   }

--- a/buckaroo/GitCli.fs
+++ b/buckaroo/GitCli.fs
@@ -222,6 +222,7 @@ type GitCli (console : ConsoleManager) =
                 return (skip + (nextList |> List.length), nextList, fetchNext)
               })
               ( 0, List.empty, async { return () } )
+          |> AsyncSeq.takeWhile (fun (_, revs, _) -> revs.Length > 0)
           |> AsyncSeq.collect (fun (_, revs, fetchNext) -> asyncSeq {
             yield! revs |> AsyncSeq.ofSeq
             do! fetchNext


### PR DESCRIPTION
In some cases we mistakenly perform  a`git fetch origin <commithash>:<commithash>` which confuses git when you try to checkout <commithash> as then it does not know whether you mean the created ref or actual commit. 

Furthermore we always fetch upto 13 times in our deepening algorithm before we terminate the deepening process. 

This fix speeds up the process of resolving significantly.