### PR TITLE
feat: implements cache first option for remoterefs fetching

### DIFF
--- a/buckaroo-cli/Program.fs
+++ b/buckaroo-cli/Program.fs
@@ -15,10 +15,10 @@ let main argv =
     let! exitCode = async {
       try
         match Buckaroo.Command.parse input with
-        | Result.Ok (command, loggingLevel) ->
+        | Result.Ok (command, loggingLevel, fetchStyle) ->
           do!
             command
-            |> Buckaroo.Command.runCommand loggingLevel
+            |> Buckaroo.Command.runCommand loggingLevel fetchStyle
           return 0
         | Result.Error error ->
           Console.WriteLine error

--- a/buckaroo-tests/Command.fs
+++ b/buckaroo-tests/Command.fs
@@ -15,32 +15,37 @@ let private ijkXyz = GitHub { Owner = "ijk"; Project = "xyz" }
 [<Fact>]
 let ``Command.parse works correctly`` () =
   let cases = [
-    (Result.Ok (Command.Init, defaultLoggingLevel), "init");
+    (Result.Ok (Command.Init, defaultLoggingLevel, RemoteFirst), "init");
 
-    (Result.Ok (Command.Install, defaultLoggingLevel), "   install  ");
+    (Result.Ok (Command.Install, defaultLoggingLevel, RemoteFirst), "   install  ");
 
-    (Result.Ok (Command.Resolve Quick, defaultLoggingLevel), "resolve");
-    (Result.Ok (Command.Resolve Quick, verboseLoggingLevel), "resolve --verbose");
-    (Result.Ok (Command.Resolve Upgrading, defaultLoggingLevel), "resolve  --upgrade    ");
-    (Result.Ok (Command.Resolve Upgrading, verboseLoggingLevel), "resolve --upgrade   --verbose");
+    (Result.Ok (Command.Resolve Quick, defaultLoggingLevel, RemoteFirst), "resolve");
+    (Result.Ok (Command.Resolve Quick, verboseLoggingLevel, RemoteFirst), "resolve --verbose");
+    (Result.Ok (Command.Resolve Upgrading, defaultLoggingLevel, RemoteFirst), "resolve  --upgrade    ");
+    (Result.Ok (Command.Resolve Upgrading, verboseLoggingLevel, RemoteFirst), "resolve --upgrade  --verbose");
+    (Result.Ok (Command.Resolve Quick, defaultLoggingLevel, CacheFirst), "resolve --cache-first ");
+    (Result.Ok (Command.Resolve Quick, verboseLoggingLevel, CacheFirst), "resolve --cache-first --verbose");
 
-    (Result.Ok (Command.UpgradeDependencies [], defaultLoggingLevel), "upgrade");
-    (Result.Ok (Command.UpgradeDependencies [ abcDef ], defaultLoggingLevel), "upgrade  abc/def");
-    (Result.Ok (Command.UpgradeDependencies [], verboseLoggingLevel), "  upgrade  --verbose  ");
-    (Result.Ok (Command.UpgradeDependencies [ abcDef ], verboseLoggingLevel), "upgrade  abc/def --verbose ");
+    (Result.Ok (Command.UpgradeDependencies [], defaultLoggingLevel, RemoteFirst), "upgrade");
+    (Result.Ok (Command.UpgradeDependencies [ abcDef ], defaultLoggingLevel, RemoteFirst), "upgrade  abc/def");
+    (Result.Ok (Command.UpgradeDependencies [], verboseLoggingLevel, RemoteFirst), "  upgrade  --verbose  ");
+    (Result.Ok (Command.UpgradeDependencies [ abcDef ], verboseLoggingLevel, RemoteFirst), "upgrade  abc/def --verbose ");
+    (Result.Ok (Command.UpgradeDependencies [], verboseLoggingLevel, CacheFirst), "  upgrade  --cache-first --verbose  ");
+    (Result.Ok (Command.UpgradeDependencies [ abcDef ], verboseLoggingLevel, CacheFirst), "upgrade  abc/def --cache-first --verbose ");
 
     (
       Result.Ok
         (
           Command.AddDependencies
             [ { Package = ijkXyz; Constraint = Constraint.wildcard; Targets = None } ],
-          defaultLoggingLevel
+          defaultLoggingLevel,
+          RemoteFirst
         ),
       "add github.com/ijk/xyz  "
     );
 
     (
-      Result.Ok (Command.UpgradeDependencies [ abcDef; ijkXyz ], verboseLoggingLevel),
+      Result.Ok (Command.UpgradeDependencies [ abcDef; ijkXyz ], verboseLoggingLevel, RemoteFirst),
       "upgrade  abc/def github.com/ijk/xyz --verbose "
     );
   ]
@@ -48,8 +53,8 @@ let ``Command.parse works correctly`` () =
   for (expected, input) in cases do
     let actual = Command.parse input
 
-    match actual with
-    | Result.Error error ->
+    match actual, expected with
+    | Result.Error error, _ ->
       System.Console.WriteLine (error + "\nfor \"" + input + "\"")
     | _ -> ()
 

--- a/buckaroo-tests/Command.fs
+++ b/buckaroo-tests/Command.fs
@@ -53,8 +53,8 @@ let ``Command.parse works correctly`` () =
   for (expected, input) in cases do
     let actual = Command.parse input
 
-    match actual, expected with
-    | Result.Error error, _ ->
+    match actual with
+    | Result.Error error ->
       System.Console.WriteLine (error + "\nfor \"" + input + "\"")
     | _ -> ()
 

--- a/buckaroo-tests/Solver.fs
+++ b/buckaroo-tests/Solver.fs
@@ -125,7 +125,7 @@ let solve (partial : Solution) (cookBook : CookBook) (lockBookEntries : LockBook
   let context : TaskContext = {
     Console = console
     DownloadManager = DownloadManager(console, "/tmp")
-    GitManager = new GitManager(console, new GitCli(console), "/tmp")
+    GitManager = new GitManager(CacheFirst, console, new GitCli(console), "/tmp")
     SourceExplorer = TestingSourceExplorer(cookBook, lockBook)
   }
 

--- a/buckaroo/Command.fs
+++ b/buckaroo/Command.fs
@@ -179,12 +179,23 @@ module Command =
 
     let! isCacheFirst = cacheFirstParser
     do! CharParsers.spaces
-    let! isVerbose = verboseParser
 
+    let! isVerbose = verboseParser
     do! CharParsers.spaces
 
-    let loggingLevel = if isVerbose then LoggingLevel.Trace else LoggingLevel.Info
-    let fetchStyle = if isCacheFirst then CacheFirst else RemoteFirst
+    let loggingLevel =
+      if isVerbose
+      then
+        LoggingLevel.Trace
+      else
+        LoggingLevel.Info
+
+    let fetchStyle =
+      if isCacheFirst
+      then
+        CacheFirst
+      else
+        RemoteFirst
 
     return (command, loggingLevel, fetchStyle)
   }

--- a/buckaroo/GitManager.fs
+++ b/buckaroo/GitManager.fs
@@ -15,7 +15,11 @@ type GitManagerRequest =
 | CloneRequest of string * AsyncReplyChannel<Async<string>>
 | FetchRefs of string * AsyncReplyChannel<Async<Ref list>>
 
-type GitManager (console : ConsoleManager, git : IGit, cacheDirectory : string) =
+type FetchStyle =
+| RemoteFirst
+| CacheFirst
+
+type GitManager (style: FetchStyle, console : ConsoleManager, git : IGit, cacheDirectory : string) =
 
   let logger = createLogger console (Some "git")
 
@@ -44,6 +48,20 @@ type GitManager (console : ConsoleManager, git : IGit, cacheDirectory : string) 
       |> bytesToHex
     let folder = sanitizeFilename(url).ToLower() + "-" + hash.Substring(0, 16)
     Path.Combine(cacheDirectory, folder)
+
+  let pickRefsToFetch (style: FetchStyle) (remote : Async<List<Ref>>) (cache: Async<List<Ref>>) = async {
+    match style with
+    | RemoteFirst ->
+      let! x = remote
+      if x |> List.isEmpty then
+        return x
+      else return! cache
+    | CacheFirst ->
+      let! x = cache
+      if x |> List.isEmpty then
+        return x
+      else return! remote
+  }
 
   let mailboxCloneProcessor = MailboxProcessor.Start(fun inbox -> async {
     let mutable cloneCache : Map<string, Async<string>> = Map.empty
@@ -78,31 +96,19 @@ type GitManager (console : ConsoleManager, git : IGit, cacheDirectory : string) 
               let startTime = System.DateTime.Now
 
               let! refs =
-                Async.Parallel
-                  (
-                    (
-                      git.RemoteRefs url
-                      |> Async.Catch
-                      |> Async.map (Choice.toOption >> Option.defaultValue([]))
-                    ),
-                    (
-                      git.RemoteRefs cacheDir
-                      |> Async.Catch
-                      |> Async.map (Choice.toOption >> Option.defaultValue([]))
-                    )
-                  )
-                |> Async.map(fun (a, b) ->
-                  if a.Length = 0 && b.Length = 0
-                  then
-                    raise <| SystemException("No internet connection and the cache is empty")
-                  else if a.Length > 0
-                  then
-                    a
-                  else
-                    b
-                )
+                pickRefsToFetch
+                  style
+                  (git.RemoteRefs url
+                    |> Async.Catch
+                    |> Async.map (Choice.toOption >> Option.defaultValue([])))
+                  (git.RemoteRefs cacheDir
+                    |> Async.Catch
+                    |> Async.map (Choice.toOption >> Option.defaultValue([])))
 
               let endTime = System.DateTime.Now
+
+              if refs |> List.isEmpty then
+                raise <| SystemException("No internet connection and the cache is empty")
 
               logger.RichSuccess(
                 (text "Fetched ") +

--- a/buckaroo/GitManager.fs
+++ b/buckaroo/GitManager.fs
@@ -53,12 +53,12 @@ type GitManager (style: FetchStyle, console : ConsoleManager, git : IGit, cacheD
     match style with
     | RemoteFirst ->
       let! x = remote
-      if x |> List.isEmpty then
+      if x |> List.isEmpty |> not then
         return x
       else return! cache
     | CacheFirst ->
       let! x = cache
-      if x |> List.isEmpty then
+      if x |> List.isEmpty |> not then
         return x
       else return! remote
   }

--- a/buckaroo/Solver.fs
+++ b/buckaroo/Solver.fs
@@ -258,13 +258,13 @@ let resolutionManager (sourceExplorer : ISourceExplorer) : MailboxProcessor<Reso
           match candidate with
           | Result.Error (Unresolvable d) ->
             unresolvableCores <- (unresolvableCores |> Map.add (Set [d]) (Unresolvable d))
-            printCores()
+            //printCores()
             yield Result.Error <| Unresolvable d
           | Result.Error (LimitReached (d, MaxConsecutiveFailures)) ->
             if hadCandidate
             then
               underconstraintDeps <- (underconstraintDeps |> Set.add d)
-              printCores()
+              //printCores()
 
             yield Result.Error <| LimitReached (d, MaxConsecutiveFailures)
           | Result.Ok (_, (location, versions)) ->
@@ -420,7 +420,7 @@ let resolutionManager (sourceExplorer : ISourceExplorer) : MailboxProcessor<Reso
                   |> Set.add failedDep
 
                 unresolvableCores <- unresolvableCores |> Map.add core (SearchStrategyError.Unresolvable (p, bs))
-                printCores()
+                //printCores()
           | _ -> ()
 
 

--- a/buckaroo/Tasks.fs
+++ b/buckaroo/Tasks.fs
@@ -30,7 +30,7 @@ let private getCachePath = async {
     | path -> path
 }
 
-let getContext loggingLevel = async {
+let getContext loggingLevel (fetchStyle : FetchStyle) = async {
   let consoleManager = ConsoleManager(loggingLevel)
 
   let! cachePath = getCachePath
@@ -53,7 +53,7 @@ let getContext loggingLevel = async {
       then GitLib(consoleManager) :> IGit
       else GitCli(consoleManager) :> IGit
 
-  let gitManager = GitManager(consoleManager, git, cachePath)
+  let gitManager = GitManager(fetchStyle, consoleManager, git, cachePath)
   let sourceExplorer = DefaultSourceExplorer(consoleManager, downloadManager, gitManager)
 
   return {

--- a/buckaroo/Tasks.fs
+++ b/buckaroo/Tasks.fs
@@ -30,7 +30,7 @@ let private getCachePath = async {
     | path -> path
 }
 
-let getContext loggingLevel (fetchStyle : FetchStyle) = async {
+let getContext loggingLevel fetchStyle = async {
   let consoleManager = ConsoleManager(loggingLevel)
 
   let! cachePath = getCachePath


### PR DESCRIPTION
`git ls-remote` is a slow operation. This PR adds the option `--cache-first` allowing the user to skip the syncing of the local cache with the remote if possible.
This speeds-up resolution significantly (more than 10x) but may result in a set of packages that is not up-to-date