### PR TITLE
Features (WIP).

### DIFF
--- a/buckaroo-tests/Command.fs
+++ b/buckaroo-tests/Command.fs
@@ -37,7 +37,7 @@ let ``Command.parse works correctly`` () =
       Result.Ok
         (
           Command.AddDependencies
-            [ { Package = ijkXyz; Constraint = Constraint.wildcard; Targets = None; Features = None } ],
+            [ { Package = ijkXyz; Constraint = Constraint.wildcard; Targets = None; Features = None; Conditions = None } ],
           defaultLoggingLevel,
           RemoteFirst
         ),

--- a/buckaroo-tests/Command.fs
+++ b/buckaroo-tests/Command.fs
@@ -37,7 +37,7 @@ let ``Command.parse works correctly`` () =
       Result.Ok
         (
           Command.AddDependencies
-            [ { Package = ijkXyz; Constraint = Constraint.wildcard; Targets = None } ],
+            [ { Package = ijkXyz; Constraint = Constraint.wildcard; Targets = None; Features = None } ],
           defaultLoggingLevel,
           RemoteFirst
         ),

--- a/buckaroo-tests/Dependency.fs
+++ b/buckaroo-tests/Dependency.fs
@@ -9,7 +9,7 @@ open Buckaroo
 let ``Dependency.parse works correctly`` () =
   let p = PackageIdentifier.GitHub { Owner = "abc"; Project = "def" }
   let cases = [
-    ("github.com/abc/def@*", { Package = p; Constraint = Constraint.wildcard; Targets = None; Features = None } |> Result.Ok)
+    ("github.com/abc/def@*", { Package = p; Constraint = Constraint.wildcard; Targets = None; Features = None; Conditions = None } |> Result.Ok)
     // TODO: 
     // ("github.com/abc/def@*//:foo", { Package = p; Constraint = Constraint.wildcard; Targets = Some [ { Folders = []; Name = "foo" } ] } |> Result.Ok)
     // ("", Result.Error ""); 

--- a/buckaroo-tests/Dependency.fs
+++ b/buckaroo-tests/Dependency.fs
@@ -9,7 +9,7 @@ open Buckaroo
 let ``Dependency.parse works correctly`` () =
   let p = PackageIdentifier.GitHub { Owner = "abc"; Project = "def" }
   let cases = [
-    ("github.com/abc/def@*", { Package = p; Constraint = Constraint.wildcard; Targets = None } |> Result.Ok)
+    ("github.com/abc/def@*", { Package = p; Constraint = Constraint.wildcard; Targets = None; Features = None } |> Result.Ok)
     // TODO: 
     // ("github.com/abc/def@*//:foo", { Package = p; Constraint = Constraint.wildcard; Targets = Some [ { Folders = []; Name = "foo" } ] } |> Result.Ok)
     // ("", Result.Error ""); 

--- a/buckaroo-tests/Manifest.fs
+++ b/buckaroo-tests/Manifest.fs
@@ -6,21 +6,21 @@ open FSharpx
 
 open Buckaroo
 open Buckaroo.Tests
-open Buckaroo
-open Buckaroo.Tests
 
 [<Fact>]
 let ``Manifest.parse works correctly`` () =
   let a = {
     Package = PackageIdentifier.GitHub { Owner = "abc"; Project = "def" };
     Constraint = Constraint.wildcard;
-    Targets = None
+    Targets = None;
+    Features = None;
   }
 
   let b = {
     Package = PackageIdentifier.GitHub { Owner = "ijk"; Project = "xyz" };
     Constraint = Constraint.wildcard;
-    Targets = Some [ { Folders = []; Name = "foo" } ]
+    Targets = Some [ { Folders = []; Name = "foo" } ];
+    Features = None;
   }
 
   let lmnqrs = { Owner = "lmn"; Project = "qrs" }
@@ -29,6 +29,7 @@ let ``Manifest.parse works correctly`` () =
     Package = PackageIdentifier.Adhoc lmnqrs;
     Constraint = Constraint.wildcard;
     Targets = None;
+    Features = None;
   }
 
   let locationC =
@@ -89,10 +90,21 @@ let ``Manifest.toToml roundtrip 1`` () =
         Targets = Some ([{Folders=["foo"; "bar"]; Name = "xxx"}])
         Constraint = All <| Set[Constraint.Exactly (Version.SemVer SemVer.zero)]
         Package = PackageIdentifier.GitHub { Owner = "abc"; Project = "def" }
+        Features = ([
+          ("profile", "core" |> FeatureUnitValue.String |> FeatureValue.Value);
+          ("api", FeatureValue.Dictionary ([
+            ("gl", "3.2" |> FeatureUnitValue.String);
+            ("gles", "" |> FeatureUnitValue.String);
+          ] |> Map.ofSeq) );
+          ("extensions", FeatureValue.Array [
+            "GL_EXT_framebuffer_multisample" |> FeatureUnitValue.String;
+            "GL_EXT_texture_filter_anisotropic" |> FeatureUnitValue.String;
+          ] );
+        ] |> Map.ofSeq |> Some);
       }]
   }
 
-  let actual =  expected |> Manifest.toToml |> Manifest.parse
+  let actual = expected |> Manifest.toToml |> Manifest.parse
 
   // 3 new-lines indicates poor formatting
   Assert.True (
@@ -125,11 +137,33 @@ let ``Manifest.toToml roundtrip 2`` () =
       Targets = Some ([{Folders=["foo"; "bar"]; Name = "xxx"}])
       Constraint = All <| Set[Constraint.Exactly (Version.SemVer SemVer.zero)]
       Package = PackageIdentifier.GitHub { Owner = "abc"; Project = "def" }
+      Features = ([
+        ("profile", "core" |> FeatureUnitValue.String |> FeatureValue.Value);
+        ("api", FeatureValue.Dictionary ([
+          ("gl", "3.2" |> FeatureUnitValue.String);
+          ("gles", "" |> FeatureUnitValue.String);
+        ] |> Map.ofSeq) );
+        ("extensions", FeatureValue.Array [
+          "GL_EXT_framebuffer_multisample" |> FeatureUnitValue.String;
+          "GL_EXT_texture_filter_anisotropic" |> FeatureUnitValue.String;
+        ] );
+      ] |> Map.ofSeq |> Some);
     }]
     PrivateDependencies = Set [{
       Targets = Some ([{Folders=["foo"; "bar"]; Name = "yyy"}])
       Constraint = Any <|Set[Constraint.Exactly (Version.SemVer SemVer.zero)]
       Package = PackageIdentifier.GitHub { Owner = "abc"; Project = "def" }
+      Features = ([
+        ("profile", "core" |> FeatureUnitValue.String |> FeatureValue.Value);
+        ("api", FeatureValue.Dictionary ([
+          ("gl", "3.2" |> FeatureUnitValue.String);
+          ("gles", "" |> FeatureUnitValue.String);
+        ] |> Map.ofSeq) );
+        ("extensions", FeatureValue.Array [
+          "GL_EXT_framebuffer_multisample" |> FeatureUnitValue.String;
+          "GL_EXT_texture_filter_anisotropic" |> FeatureUnitValue.String;
+        ] );
+      ] |> Map.ofSeq |> Some);
     }]
   }
 

--- a/buckaroo-tests/Manifest.fs
+++ b/buckaroo-tests/Manifest.fs
@@ -14,6 +14,7 @@ let ``Manifest.parse works correctly`` () =
     Constraint = Constraint.wildcard;
     Targets = None;
     Features = None;
+    Conditions = None;
   }
 
   let b = {
@@ -21,6 +22,7 @@ let ``Manifest.parse works correctly`` () =
     Constraint = Constraint.wildcard;
     Targets = Some [ { Folders = []; Name = "foo" } ];
     Features = None;
+    Conditions = None;
   }
 
   let lmnqrs = { Owner = "lmn"; Project = "qrs" }
@@ -30,6 +32,7 @@ let ``Manifest.parse works correctly`` () =
     Constraint = Constraint.wildcard;
     Targets = None;
     Features = None;
+    Conditions = None;
   }
 
   let locationC =
@@ -101,6 +104,15 @@ let ``Manifest.toToml roundtrip 1`` () =
             "GL_EXT_texture_filter_anisotropic" |> FeatureUnitValue.String;
           ] );
         ] |> Map.ofSeq |> Some);
+        Conditions = [{
+          Source = "gl > 3";
+          Expression =
+            Expression.BinaryExpression (
+              Expression.Variable "gl",
+              BinaryOperator.More,
+              Expression.Value (3 |> int64 |> FeatureUnitValue.Integer |> FeatureValue.Value)
+            );
+        }] |> Some;
       }]
   }
 
@@ -148,6 +160,7 @@ let ``Manifest.toToml roundtrip 2`` () =
           "GL_EXT_texture_filter_anisotropic" |> FeatureUnitValue.String;
         ] );
       ] |> Map.ofSeq |> Some);
+      Conditions = None;
     }]
     PrivateDependencies = Set [{
       Targets = Some ([{Folders=["foo"; "bar"]; Name = "yyy"}])
@@ -164,6 +177,7 @@ let ``Manifest.toToml roundtrip 2`` () =
           "GL_EXT_texture_filter_anisotropic" |> FeatureUnitValue.String;
         ] );
       ] |> Map.ofSeq |> Some);
+      Conditions = None;
     }]
   }
 

--- a/buckaroo-tests/Solver.fs
+++ b/buckaroo-tests/Solver.fs
@@ -24,7 +24,8 @@ let ver (x : int) = Version.SemVer {SemVer.zero with Major = x}
 let dep (p : string, c: Constraint) : Buckaroo.Dependency = {
     Package = package p;
     Constraint = c;
-    Targets = None
+    Targets = None;
+    Features = None;
 }
 
 let manifest xs = {

--- a/buckaroo-tests/Solver.fs
+++ b/buckaroo-tests/Solver.fs
@@ -26,6 +26,7 @@ let dep (p : string, c: Constraint) : Buckaroo.Dependency = {
     Constraint = c;
     Targets = None;
     Features = None;
+    Conditions = None;
 }
 
 let manifest xs = {

--- a/buckaroo/BuckConfig.fs
+++ b/buckaroo/BuckConfig.fs
@@ -13,8 +13,8 @@ type INIData = Map<string, Map<INIKey,INIValue>>
 let rec renderValue (value : INIValue) : string = 
   match value with 
   | INIString s -> s
-  | INITuple xs -> xs |> Seq.map renderValue  |> String.concat ", "
-  | INIList xs -> xs |> Seq.map renderValue  |> String.concat ", "
+  | INITuple xs -> xs |> Seq.map renderValue |> String.concat " "
+  | INIList xs -> xs |> Seq.map renderValue |> String.concat " "
   | INIEmpty -> ""
 
 let renderSection (section : Map<INIKey, INIValue>) : string = 

--- a/buckaroo/Command.fs
+++ b/buckaroo/Command.fs
@@ -109,6 +109,7 @@ module Command =
               Constraint = c;
               Targets = None;
               Features = None;
+              Conditions = None;
             }
         } <|>
         parse {
@@ -118,6 +119,7 @@ module Command =
               Constraint = Constraint.wildcard;
               Targets = None;
               Features = None;
+              Conditions = None;
             }
         }
     }

--- a/buckaroo/Command.fs
+++ b/buckaroo/Command.fs
@@ -108,6 +108,7 @@ module Command =
               Package = p;
               Constraint = c;
               Targets = None;
+              Features = None;
             }
         } <|>
         parse {
@@ -116,6 +117,7 @@ module Command =
               Package = p;
               Constraint = Constraint.wildcard;
               Targets = None;
+              Features = None;
             }
         }
     }

--- a/buckaroo/Condition.fs
+++ b/buckaroo/Condition.fs
@@ -47,7 +47,7 @@ module ConditionParse =
       (ws >>. prev .>> ws)
       (Primitives.opt (Primitives.tuple2
         operators
-        ((parse.Delay (fun() -> compareExpressionParser)) <|> prev)
+        ((parse.Delay (fun() -> binaryOperatorParser prev operators)) <|> prev)
       ))
       (fun left rest ->
         match rest with
@@ -86,6 +86,7 @@ module ConditionParse =
     ws >>. (
       FeatureValueParse.featureValueParser |>> Value
       <|> variableParser
+      <|> (Primitives.between (str "(") (str ")") expressionParser)
     )
 
   and private expressionParser = parse.Delay (fun () ->
@@ -98,3 +99,8 @@ module ConditionParse =
     expressionParser
     .>> ws
     .>> CharParsers.eof
+
+  let parse (input : string) : Result<Condition, string> =
+    match run conditionParser input with
+    | Success(result, _, _) -> Result.Ok <| result
+    | Failure(errorMsg, _, _) -> Result.Error errorMsg

--- a/buckaroo/Condition.fs
+++ b/buckaroo/Condition.fs
@@ -18,7 +18,10 @@ type Expression =
 | NotExpression of Expression
 | BinaryExpression of Expression * BinaryOperator * Expression
 
-type Condition = Expression
+type Condition = {
+  Source : string;
+  Expression : Expression;
+}
 
 module ConditionParse =
   open FParsec
@@ -95,12 +98,15 @@ module ConditionParse =
       unitParser;
     ])
 
-  let conditionParser : Parser<Condition, unit> =
+  let private conditionParser : Parser<Expression, unit> =
     expressionParser
     .>> ws
     .>> CharParsers.eof
 
   let parse (input : string) : Result<Condition, string> =
     match run conditionParser input with
-    | Success(result, _, _) -> Result.Ok <| result
+    | Success(result, _, _) -> Result.Ok <| {
+        Source = input;
+        Expression = result;
+      }
     | Failure(errorMsg, _, _) -> Result.Error errorMsg

--- a/buckaroo/Condition.fs
+++ b/buckaroo/Condition.fs
@@ -1,0 +1,100 @@
+#nowarn "40"
+namespace Buckaroo
+
+type BinaryOperator =
+| And
+| Or
+| Equal
+| NotEqual
+| Less
+| LessEqual
+| More
+| MoreEqual
+| Contains
+
+type Expression =
+| Value of FeatureValue
+| Variable of string
+| NotExpression of Expression
+| BinaryExpression of Expression * BinaryOperator * Expression
+
+type Condition = Expression
+
+module ConditionParse =
+  open FParsec
+
+  let private ws = CharParsers.spaces
+  let private str = CharParsers.skipString
+
+  let private featureNameParser : Parser<string, unit> =
+    CharParsers.regex @"\w[\w\d]*"
+
+  let private valueParser = FeatureValueParse.featureValueParser
+  let rec private variableParser = featureNameParser |>> Variable
+
+  and private andParser = (str "and") >>. (Primitives.preturn And)
+  and private orParser = (str "or") >>. (Primitives.preturn Or)
+  and private equalParser = (str "=") >>. (Primitives.preturn Equal)
+  and private notEqualParser = (str "<>") >>. (Primitives.preturn NotEqual)
+  and private lessParser = (str "<") >>. (Primitives.preturn Less)
+  and private lessEqualParser = (str "<=") >>. (Primitives.preturn LessEqual)
+  and private moreParser = (str ">") >>. (Primitives.preturn More)
+  and private moreEqualParser = (str ">=") >>. (Primitives.preturn MoreEqual)
+  and private containsParser = (str "contains") >>. (Primitives.preturn Contains)
+
+  and private binaryOperatorParser prev operators =
+    Primitives.pipe2
+      (ws >>. prev .>> ws)
+      (Primitives.opt (Primitives.tuple2
+        operators
+        ((parse.Delay (fun() -> compareExpressionParser)) <|> prev)
+      ))
+      (fun left rest ->
+        match rest with
+        | None -> left
+        | Some (operator, right) -> BinaryExpression (left, operator, right)
+      )
+
+  and private compareExpressionParser =
+    binaryOperatorParser
+      unitParser
+      (
+        equalParser
+        <|> notEqualParser
+        <|> lessParser
+        <|> lessEqualParser
+        <|> moreParser
+        <|> moreEqualParser
+        <|> containsParser
+      )
+
+  and private notOperatorExpressionParser =
+    (ws >>. (str "not") >>. ws >>. compareExpressionParser |>> NotExpression)
+    <|> compareExpressionParser
+
+  and private logicalExpressionParser =
+    binaryOperatorParser
+      notOperatorExpressionParser
+      (
+        andParser
+        <|> orParser
+      )
+
+  and private binaryOperatorExpressionParser = logicalExpressionParser
+
+  and private unitParser =
+    ws >>. (
+      FeatureValueParse.featureValueParser |>> Value
+      <|> variableParser
+    )
+
+  and private expressionParser = parse.Delay (fun () ->
+    Primitives.choice [
+      binaryOperatorExpressionParser;
+      unitParser;
+    ])
+
+  let conditionParser : Parser<Condition, unit> =
+    expressionParser
+    .>> ws
+    .>> CharParsers.eof

--- a/buckaroo/Dependency.fs
+++ b/buckaroo/Dependency.fs
@@ -3,7 +3,8 @@ namespace Buckaroo
 type Dependency = {
   Package : PackageIdentifier;
   Constraint : Constraint;
-  Targets : Target list option
+  Targets : Target list option;
+  Features : Map<string, FeatureValue> option;
 }
 
 module Dependency =
@@ -55,7 +56,7 @@ module Dependency =
     do! CharParsers.skipString "@"
     let! c = Constraint.parser
     return
-      { Package = p; Constraint = c; Targets = None }
+      { Package = p; Constraint = c; Targets = None; Features = None }
   }
 
   let parse (x : string) : Result<Dependency, string> =

--- a/buckaroo/Dependency.fs
+++ b/buckaroo/Dependency.fs
@@ -5,6 +5,7 @@ type Dependency = {
   Constraint : Constraint;
   Targets : Target list option;
   Features : Map<string, FeatureValue> option;
+  Conditions : Condition list option;
 }
 
 module Dependency =
@@ -56,7 +57,7 @@ module Dependency =
     do! CharParsers.skipString "@"
     let! c = Constraint.parser
     return
-      { Package = p; Constraint = c; Targets = None; Features = None }
+      { Package = p; Constraint = c; Targets = None; Features = None; Conditions = None }
   }
 
   let parse (x : string) : Result<Dependency, string> =

--- a/buckaroo/Escape.fs
+++ b/buckaroo/Escape.fs
@@ -1,0 +1,15 @@
+namespace Buckaroo
+
+
+module Escape =
+  open System.Text.RegularExpressions
+
+  let escapeRegex = Regex(@"([\'""])")
+  let escapeReplacement = "\\$1"
+
+  let escape (quote : string) (input : string) =
+    quote + escapeRegex.Replace(input, escapeReplacement) + quote
+
+  let escapeWithoutQuotes = escape ""
+  let escapeWithSingleQuotes = escape "'"
+  let escapeWithDoubleQuotes = escape "\""

--- a/buckaroo/Feature.fs
+++ b/buckaroo/Feature.fs
@@ -1,0 +1,65 @@
+namespace Buckaroo
+
+open Buckaroo.Result
+open Buckaroo.Toml
+
+
+type FeatureUnitValue =
+| Boolean of bool
+| Integer of int64
+| Float of float
+| String of string
+// | Version of Version
+
+type FeatureValue =
+| Value of FeatureUnitValue
+| Dictionary of Map<string, FeatureUnitValue>
+| Array of List<FeatureUnitValue>
+
+
+module FeatureUnitValue =
+  let show (x : FeatureUnitValue) : string =
+    match x with
+    | Boolean x -> if x then "true" else "false"
+    | Integer x -> x.ToString()
+    | Float x -> x.ToString()
+    | String x -> "\"" + x + "\""
+
+  let fromToml (toml : Nett.TomlObject) : Result<FeatureUnitValue, TomlError> =
+    match toml with
+    | :? Nett.TomlBool as v -> FeatureUnitValue.Boolean v.Value |> Result.Ok
+    | :? Nett.TomlInt as v -> FeatureUnitValue.Integer v.Value |> Result.Ok
+    | :? Nett.TomlFloat as v -> FeatureUnitValue.Float v.Value |> Result.Ok
+    | :? Nett.TomlString as v -> FeatureUnitValue.String v.Value |> Result.Ok
+    | _ -> TomlError.UnexpectedType toml.ReadableTypeName |> Result.Error
+
+module FeatureValue =
+  let show (x : FeatureValue) =
+    match x with
+    | Value x -> x |> FeatureUnitValue.show
+    | Dictionary x ->
+      "{ " + (x
+        |> Map.toSeq
+        |> Seq.map (fun (a, b) -> a + " = " + (FeatureUnitValue.show b))
+        |> String.concat ", "
+      ) + " }"
+    | Array x -> "[ " + (x |> Seq.map FeatureUnitValue.show |> String.concat ", ") + " ]"
+
+  let fromToml (toml : Nett.TomlObject) : Result<FeatureValue, TomlError> =
+    match FeatureUnitValue.fromToml toml with
+    | Result.Ok r -> FeatureValue.Value r |> Result.Ok
+    | Result.Error e ->
+      match toml with
+      | :? Nett.TomlTable as v ->
+        v.Keys
+        |> Seq.map (fun key ->
+          FeatureUnitValue.fromToml (v.Item key) |> Result.map(fun value -> (key, value))
+        )
+        |> all
+        |> Result.map (List.rev >> Map.ofList >> FeatureValue.Dictionary)
+      | :? Nett.TomlArray as v ->
+        v.Items
+        |> Seq.map FeatureUnitValue.fromToml
+        |> all
+        |> Result.map (List.rev >> FeatureValue.Array)
+      | _ -> e |> Result.Error

--- a/buckaroo/buckaroo.fsproj
+++ b/buckaroo/buckaroo.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Paths.fs" />
     <Compile Include="ArchiveType.fs" />
     <Compile Include="Toml.fs" />
+    <Compile Include="Escape.fs" />
     <Compile Include="BuckConfig.fs" />
     <Compile Include="Files.fs" />
     <Compile Include="Archive.fs" />

--- a/buckaroo/buckaroo.fsproj
+++ b/buckaroo/buckaroo.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="Version.fs" />
     <Compile Include="Constraint.fs" />
     <Compile Include="Atom.fs" />
+    <Compile Include="Feature.fs" />
     <Compile Include="Dependency.fs" />
     <Compile Include="PackageLocation.fs" />
     <Compile Include="PackageSource.fs" />

--- a/buckaroo/buckaroo.fsproj
+++ b/buckaroo/buckaroo.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="Constraint.fs" />
     <Compile Include="Atom.fs" />
     <Compile Include="Feature.fs" />
+    <Compile Include="Condition.fs" />
     <Compile Include="Dependency.fs" />
     <Compile Include="PackageLocation.fs" />
     <Compile Include="PackageSource.fs" />


### PR DESCRIPTION
An ability to pass parameters (features) to dependencies and to use them in `BUCK` configs. Features comes with condition system allowing to disable dependencies based on dependencies.

## Description
Features can be set for each dependency. Here is an example:
```toml
[[dependency]]
package = "github.com/buckaroo-pm/glfw"
version = "branch=master"

  [[dependency.feature]]
  name = "profile"
  value = "core"

  [[dependency.feature]]
  name = "api"
  value = { gl = "3.2", gles = "" }

  [[dependency.feature]]
  name = "extensions"
  value = [
    "GL_EXT_framebuffer_multisample",
    "GL_EXT_texture_filter_anisotropic"
  ]
```
GLAD library itself has a generator script which can be called using `gen_rule` from `BUCK`. So, features will allow to configure the script.

### Feature types
Current implementation will have these types:
 - `boolean`
 - `integer`
 - `string`
 - `dict` - associative container with string key and any value of plain types
 - `list` - list of any plain values

### Conditions
Conditions are the way to disable some of dependencies based on passed features. Example:
```
[[dependency]]
package = "github.com/buckaroo-pm/host-pthread"
version = "branch=master"
condition = "use_threads"
```

`condition` field can be array, then the dependency will be enabled when at least one of conditions are true.

Condition text is python-like expression, but with very limited syntax.

#### Condition evaluation
If a feature used in condition is not specified, the condition will be false.
List of operators:
```toml
condition = "feature1" # for boolean features
condition = "feature >= 5" # for integers/versions
condition = "feature = 'abc'" # for previous ones/strings
condition = "feature contains 'something'" # for arrays (has value)/dicts (has key)
condition = "feature contains ['something', 'something']" # the same, but a few operands (all should satishfy the condition)
condition = "feature = 'abc > 5 and abc < 10'"
condition = "feature = 'abc > 5 or def > 10'"
condition = "feature = 'abc > 5 or (abc > 2 and def > 10)"
```

Also, there can be single `not` prefix which inverts the result of condition evaluation. Example:
```toml
condition = "not 'something' in feature"
```

## Related Issue
Closes #344

## Motivation and Context
It is very useful feature to pass some parameters to universal dependencies. This is very common in C++ code, especially in cross-platform libraries.

Useful links:
 - https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section

## How Has This Been Tested?
Still WIP

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

## Progress:
- [x] Feature parsing.
- [x] Condition parsing.
- [x] Feature value passing.
- [ ] Condition checking.
